### PR TITLE
Add regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ DOCS = README.md
 REGRESS = $(MODULES)
 
 SQL_IN = $(MODULES).sql.in
-EXTRA_CLEAN = sql/$(MODULES).sql expected/$(MODULES).out
 
 USE_EXTENSION = $(shell pg_config --version | grep -qE " 8\.|9\.0" && echo no || echo yes)
 

--- a/expected/prioritize.out
+++ b/expected/prioritize.out
@@ -1,0 +1,42 @@
+CREATE EXTENSION prioritize;
+SELECT get_backend_priority(pg_backend_pid());
+ get_backend_priority 
+----------------------
+                    0
+(1 row)
+
+SELECT set_backend_priority(pg_backend_pid(), -5);
+WARNING:  setpriority(): permission denied
+ set_backend_priority 
+----------------------
+ f
+(1 row)
+
+SET client_min_messages = warning;
+SELECT set_backend_priority(pg_backend_pid(), 5);
+ set_backend_priority 
+----------------------
+ t
+(1 row)
+
+RESET client_min_messages;
+SELECT get_backend_priority(pg_backend_pid());
+ get_backend_priority 
+----------------------
+                    5
+(1 row)
+
+SELECT get_backend_priority(1);
+WARNING:  PID 1 is not a PostgreSQL server process
+ get_backend_priority 
+----------------------
+                     
+(1 row)
+
+SELECT set_backend_priority(1, 5);
+WARNING:  PID 1 is not a PostgreSQL server process
+ set_backend_priority 
+----------------------
+ f
+(1 row)
+

--- a/sql/prioritize.sql
+++ b/sql/prioritize.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION prioritize;
+
+SELECT get_backend_priority(pg_backend_pid());
+SELECT set_backend_priority(pg_backend_pid(), -5);
+SET client_min_messages = warning;
+SELECT set_backend_priority(pg_backend_pid(), 5);
+RESET client_min_messages;
+SELECT get_backend_priority(pg_backend_pid());
+
+SELECT get_backend_priority(1);
+SELECT set_backend_priority(1, 5);


### PR DESCRIPTION
This adds standard "make installcheck" regression tests to
pg_prioritize. Tested with PostgreSQL 9.1 .. 9.6.
